### PR TITLE
workflows: add test runs triggered by push actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Run Tests
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  fetch-and-test:
+    runs-on: self-hosted
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: heusalagroup/test
+          submodules: recursive
+      - name: set submodule branch
+        run: |
+          repo="${{ github.repository }}"; repo="${repo//./\/}"; repo="${repo/heusalagroup/}"; cd src$repo;
+          git checkout ${{ github.ref_name }}
+      - name: run tests
+        run: NODE_ENV="dev" npm run test:ci


### PR DESCRIPTION
This depends on https://github.com/heusalagroup/fi.hg.discord/pull/1 which is blocking testing a bit.

Having that fix in separate branches and testing that way did not go too well, since the checkout-action seems to reset the branches/refs during the workflow which... seems a bit odd.
