### PR TITLE
Added support to handle line breaks by default replacing as spaces

### DIFF
--- a/Csv.test.ts
+++ b/Csv.test.ts
@@ -286,6 +286,103 @@ describe('Csv', () => {
          );
       });
 
+      test('can stringify csv data with data linebreak removed', () => {
+         const result = stringifyCsv(
+             [
+                [ 'ticketNumber',
+                   'title',
+                   'categoryType',
+                   'state',
+                   'priority',
+                   'requester',
+                   'cost',
+                   'detail',
+                   'currency',
+                   'status',
+                   'dueDate',
+                   'workspaceId', 'workspace', 'supplierId', 'supplier', 'approver', 'labels'
+                ],
+                [
+                   '1', 'muumipapan hattu', 'OTHER', 'REQUEST', 'STANDARD', 'haisuli@heusalagroup.fi', '45',
+                   'Kissa ei \nkestä kaamosta - pitää\npäästä koiruuksia tekemään', 'EUR', 'WAITING_APPROVAL', '2022-11-04T00:00:00+02:00', '!FSlIOckQywLzmGoePz:matrix.my.host', 'pappa', '', '', '' ]
+             ]
+             ,
+             ',', '"', '\n', ''
+         );
+         const rows = result.split('\n');
+         expect(rows[1]).toStrictEqual(
+             '1'
+             +',muumipapan hattu'
+             +',OTHER'
+             +',REQUEST'
+             +',STANDARD'
+             +',haisuli@heusalagroup.fi'
+             +',45'
+             +',Kissa ei kestä kaamosta - pitääpäästä koiruuksia tekemään'
+             +',EUR'
+             +',WAITING_APPROVAL'
+             +',2022-11-04T00:00:00+02:00'
+             +',!FSlIOckQywLzmGoePz:matrix.my.host'
+             +',pappa'
+             +','
+             +','
+             +','
+         );
+      });
+
+      test('can stringify csv data with data linebreak kept', () => {
+         const result = stringifyCsv(
+             [
+                [ 'ticketNumber',
+                   'title',
+                   'categoryType',
+                   'state',
+                   'priority',
+                   'requester',
+                   'cost',
+                   'detail',
+                   'currency',
+                   'status',
+                   'dueDate',
+                   'workspaceId', 'workspace', 'supplierId', 'supplier', 'approver', 'labels'
+                ],
+                [
+                   '1', 'muumipapan hattu', 'OTHER', 'REQUEST', 'STANDARD', 'haisuli@heusalagroup.fi', '45',
+                   'Kissa ei \nkestä kaamosta - pitää\npäästä koiruuksia tekemään', 'EUR', 'WAITING_APPROVAL', '2022-11-04T00:00:00+02:00', '!FSlIOckQywLzmGoePz:matrix.my.host', 'pappa', '', '', '' ]
+             ]
+             ,
+             ',',
+             '"',
+             '\n',
+             false
+         );
+         const rows = result.split('\n');
+         expect(rows[1]).toStrictEqual(
+             '1'
+             +',muumipapan hattu'
+             +',OTHER'
+             +',REQUEST'
+             +',STANDARD'
+             +',haisuli@heusalagroup.fi'
+             +',45'
+             +',Kissa ei '
+         );
+         expect(rows[2]).toStrictEqual(
+      'kestä kaamosta - pitää'
+         );
+         expect(rows[3]).toStrictEqual(
+             'päästä koiruuksia tekemään'
+             +',EUR'
+             +',WAITING_APPROVAL'
+             +',2022-11-04T00:00:00+02:00'
+             +',!FSlIOckQywLzmGoePz:matrix.my.host'
+             +',pappa'
+             +','
+             +','
+             +','
+         );
+      });
+
    });
 
 });

--- a/Csv.test.ts
+++ b/Csv.test.ts
@@ -76,6 +76,62 @@ describe('Csv', () => {
          );
       })
 
+      test('can stringify csv data with leading cvs quote characters', () => {
+         const result = stringifyCsv(
+             [
+                [ 'id', 'name' ],
+                [ '1', '"name' ]
+             ],
+             ',',
+             '"',
+             '\n'
+         );
+         const rows = result.split('\n');
+         expect(rows[1]).toStrictEqual('1,"""name"');
+      })
+
+      test('can stringify csv data with middle cvs quote characters', () => {
+         const result = stringifyCsv(
+             [
+                [ 'id', 'name' ],
+                [ '1', 'hello"world' ]
+             ],
+             ',',
+             '"',
+             '\n'
+         );
+         const rows = result.split('\n');
+         expect(rows[1]).toStrictEqual('1,hello"world');
+      })
+
+      test('can stringify csv data with cvs quote characters both ways', () => {
+         const result = stringifyCsv(
+             [
+                [ 'id', 'name' ],
+                [ '1', '"hello"world"' ]
+             ],
+             ',',
+             '"',
+             '\n'
+         );
+         const rows = result.split('\n');
+         expect(rows[1]).toStrictEqual('1,"""hello""world"""');
+      })
+
+      test('can stringify csv data with suffix cvs quote characters', () => {
+         const result = stringifyCsv(
+             [
+                [ 'id', 'name' ],
+                [ '1', 'helloworld"' ]
+             ],
+             ',',
+             '"',
+             '\n'
+         );
+         const rows = result.split('\n');
+         expect(rows[1]).toStrictEqual('1,helloworld"');
+      })
+
       test('can stringify csv data with csv control characters', () => {
          const result = stringifyCsv([properties, firstLine, secondLine], ';', "'", '\t');
          const rows = result.split('\t');
@@ -158,6 +214,75 @@ describe('Csv', () => {
             +',"Hermot ei kestä kaamosta, pitää päästä lepuuttamaan"'
             +',EUR'
             +',WAITING'
+         );
+      });
+
+      test('can stringify csv data with linebreak replaced (using default)', () => {
+         const result = stringifyCsv(
+             [
+                properties, firstLine, secondLine,
+
+                [ '3', 'forth-test-title', 'ICT', 'WAITING', 'HIGH', 'Jacob', '2200,12', 'Hermot ei kestä kaamosta, ' + '\n' +
+                'pitää päästä lepuuttamaan' + '\n' +
+                'testi', 'EUR', 'WAITING'
+                ]
+             ], ',', '', '\n', ' ');
+         const rows = result.split('\n');
+         expect(rows[3]).toStrictEqual(
+             '3'
+             +',forth-test-title'
+             +',ICT'
+             +',WAITING'
+             +',HIGH'
+             +',Jacob'
+             +',"2200,12"'
+             +',"Hermot ei kestä kaamosta,  pitää päästä lepuuttamaan testi"'
+             +',EUR'
+             +',WAITING'
+         );
+      });
+
+      test('can stringify csv data with data linebreak replaced', () => {
+         const result = stringifyCsv(
+             [
+                [ 'ticketNumber',
+                   'title',
+                   'categoryType',
+                   'state',
+                   'priority',
+                   'requester',
+                   'cost',
+                   'detail',
+                   'currency',
+                   'status',
+                   'dueDate',
+                   'workspaceId', 'workspace', 'supplierId', 'supplier', 'approver', 'labels'
+                ],
+                [
+                   '1', 'muumipapan hattu', 'OTHER', 'REQUEST', 'STANDARD', 'haisuli@heusalagroup.fi', '45',
+                   'Kissa ei \nkestä kaamosta - pitää\npäästä koiruuksia tekemään', 'EUR', 'WAITING_APPROVAL', '2022-11-04T00:00:00+02:00', '!FSlIOckQywLzmGoePz:matrix.my.host', 'pappa', '', '', '' ]
+             ]
+             ,
+             ',', '"', '\n', ' '
+         );
+         const rows = result.split('\n');
+         expect(rows[1]).toStrictEqual(
+             '1'
+             +',muumipapan hattu'
+             +',OTHER'
+             +',REQUEST'
+             +',STANDARD'
+             +',haisuli@heusalagroup.fi'
+             +',45'
+             +',Kissa ei  kestä kaamosta - pitää päästä koiruuksia tekemään'
+             +',EUR'
+             +',WAITING_APPROVAL'
+             +',2022-11-04T00:00:00+02:00'
+             +',!FSlIOckQywLzmGoePz:matrix.my.host'
+             +',pappa'
+             +','
+             +','
+             +','
          );
       });
 

--- a/Csv.ts
+++ b/Csv.ts
@@ -11,8 +11,7 @@ import {
     keys,
     map,
     split,
-    startsWith,
-    replace, replaceAll
+    startsWith
 } from "./modules/lodash";
 import { ReadonlyJsonObject } from "./Json";
 
@@ -227,14 +226,13 @@ export function stringifyCsv (
     separator        : string = DEFAULT_CSV_SEPARATOR,
     quote            : string = DEFAULT_CSV_QUOTE,
     lineBreak        : string = DEFAULT_CSV_LINE_BREAK,
-    replaceLineBreak : string | undefined = DEFAULT_CSV_LINE_BREAK_REPLACE_CHARACTER
+    replaceLineBreak : string | false = DEFAULT_CSV_LINE_BREAK_REPLACE_CHARACTER
 ): string {
     separator = separator ? separator : DEFAULT_CSV_SEPARATOR;
     quote     = quote     ? quote     : DEFAULT_CSV_QUOTE;
     lineBreak = lineBreak ? lineBreak : DEFAULT_CSV_LINE_BREAK;
-    replaceLineBreak = replaceLineBreak ? replaceLineBreak : undefined;
 
-    if (replaceLineBreak !== undefined) {
+    if (replaceLineBreak !== false ) {
         value = replaceCsvContentLineBreaks(
             value,
             lineBreak,
@@ -265,7 +263,7 @@ export function replaceCsvContentLineBreaks (
         (row: CsvRow) : CsvRow =>
             map(
                 row,
-                (column: string): string => replaceAll(column, lineBreak, replaceTo)
+                (column: string): string => column.replaceAll(lineBreak, replaceTo)
             )
     );
 }

--- a/Csv.ts
+++ b/Csv.ts
@@ -11,14 +11,15 @@ import {
     keys,
     map,
     split,
-    startsWith
+    startsWith,
+    replace, replaceAll
 } from "./modules/lodash";
 import { ReadonlyJsonObject } from "./Json";
-import { LogService } from "./LogService";
 
 export const DEFAULT_CSV_SEPARATOR  = ',';
 export const DEFAULT_CSV_QUOTE      = '"';
 export const DEFAULT_CSV_LINE_BREAK = '\n';
+export const DEFAULT_CSV_LINE_BREAK_REPLACE_CHARACTER : string = ' ';
 
 // FIXME: Add unit tests
 export type CsvRow = string[];
@@ -195,7 +196,8 @@ export function parseCsv (
 export function stringifyCsvRow (
     value: CsvRow,
     separator: string = DEFAULT_CSV_SEPARATOR,
-    quote: string = DEFAULT_CSV_QUOTE
+    quote: string = DEFAULT_CSV_QUOTE,
+    lineBreak: string = DEFAULT_CSV_LINE_BREAK
 ): string {
     separator = separator ? separator : DEFAULT_CSV_SEPARATOR;
     quote     = quote     ? quote     : DEFAULT_CSV_QUOTE;
@@ -218,18 +220,52 @@ export function stringifyCsvRow (
  * @param separator
  * @param quote
  * @param lineBreak
+ * @param replaceLineBreak
  */
 export function stringifyCsv (
-    value: Csv,
-    separator: string = DEFAULT_CSV_SEPARATOR,
-    quote: string = DEFAULT_CSV_QUOTE,
-    lineBreak: string = DEFAULT_CSV_LINE_BREAK
+    value            : Csv,
+    separator        : string = DEFAULT_CSV_SEPARATOR,
+    quote            : string = DEFAULT_CSV_QUOTE,
+    lineBreak        : string = DEFAULT_CSV_LINE_BREAK,
+    replaceLineBreak : string | undefined = DEFAULT_CSV_LINE_BREAK_REPLACE_CHARACTER
 ): string {
     separator = separator ? separator : DEFAULT_CSV_SEPARATOR;
     quote     = quote     ? quote     : DEFAULT_CSV_QUOTE;
     lineBreak = lineBreak ? lineBreak : DEFAULT_CSV_LINE_BREAK;
+    replaceLineBreak = replaceLineBreak ? replaceLineBreak : undefined;
+
+    if (replaceLineBreak !== undefined) {
+        value = replaceCsvContentLineBreaks(
+            value,
+            lineBreak,
+            replaceLineBreak
+        );
+    }
+
     return map(
         value,
-        (row: CsvRow) => stringifyCsvRow(row, separator, quote)
+        (row: CsvRow) => stringifyCsvRow(row, separator, quote, lineBreak)
     ).join(lineBreak);
+}
+
+/**
+ * Can be used to modify Csv data structure so that line breaks in the Csv content
+ * are replaced to different character
+ * @param value
+ * @param lineBreak
+ * @param replaceTo
+ */
+export function replaceCsvContentLineBreaks (
+    value     : Csv,
+    lineBreak : string = DEFAULT_CSV_LINE_BREAK,
+    replaceTo : string = DEFAULT_CSV_LINE_BREAK_REPLACE_CHARACTER
+) : Csv {
+    return map(
+        value,
+        (row: CsvRow) : CsvRow =>
+            map(
+                row,
+                (column: string): string => replaceAll(column, lineBreak, replaceTo)
+            )
+    );
 }

--- a/modules/lodash.ts
+++ b/modules/lodash.ts
@@ -1491,20 +1491,6 @@ export function explainProperty (
     return isExplainOk(e) ? explainOk() : `property "${name}" ${e}`;
 }
 
-export function replaceAll (
-    value: string,
-    pattern: string,
-    replacement: string
-) : string {
-    if (replacement.indexOf(pattern) >= 0) {
-        throw new TypeError(`replaceAll: Pattern inside replacement string is currently not supported`)
-    }
-    do {
-        value = replace(value, pattern, replacement);
-    } while (value.indexOf(pattern) >= 0);
-    return value;
-}
-
 export {
     map,
     get,

--- a/modules/lodash.ts
+++ b/modules/lodash.ts
@@ -36,6 +36,7 @@ import { default as _isSafeInteger } from 'lodash/isSafeInteger.js';
 import toInteger from 'lodash/toInteger.js';
 import toSafeInteger from 'lodash/toSafeInteger.js';
 import startsWith from 'lodash/startsWith.js';
+import replace from 'lodash/replace.js';
 import endsWith from 'lodash/endsWith.js';
 import values from 'lodash/values.js';
 import join from 'lodash/join.js';
@@ -1490,6 +1491,20 @@ export function explainProperty (
     return isExplainOk(e) ? explainOk() : `property "${name}" ${e}`;
 }
 
+export function replaceAll (
+    value: string,
+    pattern: string,
+    replacement: string
+) : string {
+    if (replacement.indexOf(pattern) >= 0) {
+        throw new TypeError(`replaceAll: Pattern inside replacement string is currently not supported`)
+    }
+    do {
+        value = replace(value, pattern, replacement);
+    } while (value.indexOf(pattern) >= 0);
+    return value;
+}
+
 export {
     map,
     get,
@@ -1511,6 +1526,7 @@ export {
     toInteger,
     toSafeInteger,
     startsWith,
+    replace,
     endsWith,
     has,
     values,


### PR DESCRIPTION
The old behaviour can be enabled by changing to use `false` as the replacement character. (The commit says undefined, but that did not work, since it was replaced as the default option.)

Linebreaks can be removed completely using empty string.

Replaces https://github.com/heusalagroup/fi.hg.core/pull/22