### PR TITLE
Get more Wordpress content per request and added DTOs.

### DIFF
--- a/wordpress/WordpressClient.ts
+++ b/wordpress/WordpressClient.ts
@@ -4,32 +4,18 @@ import { LogLevel } from "../types/LogLevel";
 import { LogService } from "../LogService";
 import { HttpService } from "../HttpService";
 import { isWordpressPagesDTO, WordpressPageListDTO } from "./dto/WordpressPageListDTO";
+import { isWordpressPostsDTO, WordpressPostListDTO } from "./dto/WordpressPostListDTO";
 import { isWordpressReferencesDTO, WordpressReferenceListDTO } from "./dto/WordpressReferenceListDTO";
 import { isWordpressUserProfilesDTO, WordpressUserProfileListDTO } from "./dto/WordpressUserProfileListDTO";
 import {
-    WORD_PRESS_API_V2_PAGES, WORD_PRESS_API_V2_POSTS,
+    WORD_PRESS_API_V2_PAGES,
+    WORD_PRESS_API_V2_POSTS,
     WORD_PRESS_API_V3_REFERENCES,
     WORD_PRESS_API_V3_USERPROFILES
 } from "./wordpress-api";
-import {WordpressSlug} from "./WordpressSlug";
-
 
 
 const LOG = LogService.createLogger('WordpressClient');
-
-
-
-
-
-export interface GetPageFilterParams {
-    perPage?: number;
-    offset?: number;
-    parentId?: number;
-    slug?: WordpressSlug;
-}
-
-
-
 
 
 export class WordpressClient {
@@ -67,7 +53,7 @@ export class WordpressClient {
 
     public async getPages(): Promise<WordpressPageListDTO> {
         if (this._url.length < 1) return [];
-        const result = await HttpService.getJson(`${this._url}${WORD_PRESS_API_V2_PAGES}?per_page=100`);
+        const result = await HttpService.getJson(`${this._url}${WORD_PRESS_API_V2_PAGES}`);
         if (!isWordpressPagesDTO(result)) {
             LOG.debug(`getPages: result = `, result);
             throw new TypeError(`Result was not WordpressPageListDTO: ` + result);
@@ -75,41 +61,15 @@ export class WordpressClient {
         return result;
     }
 
-    public async getPosts(): Promise<WordpressPageListDTO> {
+    public async getPosts(): Promise<WordpressPostListDTO> {
         if (this._url.length < 1) return [];
-        const result = await HttpService.getJson(`${this._url}${WORD_PRESS_API_V2_POSTS}?per_page=100`);
-        if (!isWordpressPagesDTO(result)) {
+        const result = await HttpService.getJson(`${this._url}${WORD_PRESS_API_V2_POSTS}`);
+        if (!isWordpressPostsDTO(result)) {
             LOG.debug(`getPosts: result = `, result);
             throw new TypeError(`Result was not WordpressPostListDTO: ` + result);
         }
         return result;
     }
-
-
-    public async getPagesFiltered (pageFilters: GetPageFilterParams) {
-        if (this._url.length < 1) {
-            return [];
-        }
-        const apiUrl = `${this._url}${WORD_PRESS_API_V2_PAGES}`;
-        const paramArray: string[] = [
-            pageFilters.perPage     ? 'per_page='   + pageFilters.perPage   : undefined,
-            pageFilters.offset      ? 'offset='     + pageFilters.offset    : undefined,
-            pageFilters.parentId    ? 'parent='     + pageFilters.parentId  : undefined,
-            pageFilters.slug        ? 'slug='       + pageFilters.slug      : undefined
-        ];
-        const url = [
-            apiUrl,
-            paramArray.filter(str => (str !== undefined)).join('&')
-        ].join('?');
-
-        const result = await HttpService.getJson(url);
-        if (!isWordpressPagesDTO(result)) {
-            LOG.debug('getIndex: result = ', result);
-            throw new TypeError('Result was not WordPressPageListDTO: ' + result);
-        }
-        return result;
-    }
-
 
     public async getReferences(): Promise<WordpressReferenceListDTO> {
         if (this._url.length < 1) return [];

--- a/wordpress/WordpressClient.ts
+++ b/wordpress/WordpressClient.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2022. Heusala Group Oy <info@heusalagroup.fi>. All rights reserved.
+// Copyright (c) 2023. Heusala Group Oy <info@heusalagroup.fi>. All rights reserved.
 
 import { LogLevel } from "../types/LogLevel";
 import { LogService } from "../LogService";
@@ -6,9 +6,31 @@ import { HttpService } from "../HttpService";
 import { isWordpressPagesDTO, WordpressPageListDTO } from "./dto/WordpressPageListDTO";
 import { isWordpressReferencesDTO, WordpressReferenceListDTO } from "./dto/WordpressReferenceListDTO";
 import { isWordpressUserProfilesDTO, WordpressUserProfileListDTO } from "./dto/WordpressUserProfileListDTO";
-import { WORD_PRESS_API_V2_PAGES, WORD_PRESS_API_V3_REFERENCES, WORD_PRESS_API_V3_USERPROFILES } from "./wordpress-api";
+import {
+    WORD_PRESS_API_V2_PAGES, WORD_PRESS_API_V2_POSTS,
+    WORD_PRESS_API_V3_REFERENCES,
+    WORD_PRESS_API_V3_USERPROFILES
+} from "./wordpress-api";
+import {WordpressSlug} from "./WordpressSlug";
+
+
 
 const LOG = LogService.createLogger('WordpressClient');
+
+
+
+
+
+export interface GetPageFilterParams {
+    perPage?: number;
+    offset?: number;
+    parentId?: number;
+    slug?: WordpressSlug;
+}
+
+
+
+
 
 export class WordpressClient {
 
@@ -17,10 +39,11 @@ export class WordpressClient {
         HttpService.setLogLevel(level);
     }
 
+
     private static _defaultUrl: string = '/';
 
     private readonly _url: string;
-    private readonly _sessionId: string | undefined;
+
 
     public static setDefaultUrl(url: string) {
         this._defaultUrl = url;
@@ -40,18 +63,53 @@ export class WordpressClient {
         url: string = WordpressClient._defaultUrl,
     ) {
         this._url = url;
-        this._sessionId = undefined;
     }
 
     public async getPages(): Promise<WordpressPageListDTO> {
         if (this._url.length < 1) return [];
-        const result = await HttpService.getJson(`${this._url}${WORD_PRESS_API_V2_PAGES}`);
+        const result = await HttpService.getJson(`${this._url}${WORD_PRESS_API_V2_PAGES}?per_page=100`);
         if (!isWordpressPagesDTO(result)) {
-            LOG.debug(`getIndex: result = `, result);
-            throw new TypeError(`Result was not WordpressPageDTO: ` + result);
+            LOG.debug(`getPages: result = `, result);
+            throw new TypeError(`Result was not WordpressPageListDTO: ` + result);
         }
         return result;
     }
+
+    public async getPosts(): Promise<WordpressPageListDTO> {
+        if (this._url.length < 1) return [];
+        const result = await HttpService.getJson(`${this._url}${WORD_PRESS_API_V2_POSTS}?per_page=100`);
+        if (!isWordpressPagesDTO(result)) {
+            LOG.debug(`getPosts: result = `, result);
+            throw new TypeError(`Result was not WordpressPostListDTO: ` + result);
+        }
+        return result;
+    }
+
+
+    public async getPagesFiltered (pageFilters: GetPageFilterParams) {
+        if (this._url.length < 1) {
+            return [];
+        }
+        const apiUrl = `${this._url}${WORD_PRESS_API_V2_PAGES}`;
+        const paramArray: string[] = [
+            pageFilters.perPage     ? 'per_page='   + pageFilters.perPage   : undefined,
+            pageFilters.offset      ? 'offset='     + pageFilters.offset    : undefined,
+            pageFilters.parentId    ? 'parent='     + pageFilters.parentId  : undefined,
+            pageFilters.slug        ? 'slug='       + pageFilters.slug      : undefined
+        ];
+        const url = [
+            apiUrl,
+            paramArray.filter(str => (str !== undefined)).join('&')
+        ].join('?');
+
+        const result = await HttpService.getJson(url);
+        if (!isWordpressPagesDTO(result)) {
+            LOG.debug('getIndex: result = ', result);
+            throw new TypeError('Result was not WordPressPageListDTO: ' + result);
+        }
+        return result;
+    }
+
 
     public async getReferences(): Promise<WordpressReferenceListDTO> {
         if (this._url.length < 1) return [];

--- a/wordpress/dto/WordpressPageDTO.ts
+++ b/wordpress/dto/WordpressPageDTO.ts
@@ -24,7 +24,7 @@ export interface WordpressPageDTO {
     meta?:object;
     template?:string;
     password?:string;
-    date_gtm?: string | null;
+    date_gmt?: string | null;
     slug?: string;
 }
 
@@ -50,7 +50,7 @@ export function isWordpressPageDTO (value:any): value is WordpressPageDTO {
             'meta',
             'template',
             'password',
-            'date_gtm',
+            'date_gmt',
             'slug'
         ])
         && isString(value?.id)

--- a/wordpress/dto/WordpressPostDTO.ts
+++ b/wordpress/dto/WordpressPostDTO.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2023. Heusala Group Oy <info@heusalagroup.fi>. All rights reserved.
+
+import { WordpressEnum } from "./WordpressTypesDTO";
+import { isString } from "../../types/String";
+import { isRegularObject } from "../../types/RegularObject";
+import { hasNoOtherKeysInDevelopment } from "../../types/OtherKeys";
+
+export interface WordpressPostDTO {
+    title:{rendered:string, protected:boolean};
+    content:{rendered:string, protected:boolean};
+    excerpt?:{rendered?:string, protected?:boolean};
+    type?:string;
+    id?:string;
+    date?: string | null;
+    status?: WordpressEnum;
+    generated_slug?:string;
+    permalink_template?:string;
+    parent?:number;
+    author?:number;
+    featured_media?:number;
+    comment_status?:string;
+    ping_status?:string;
+    menu_order?:number;
+    meta?:object;
+    template?:string;
+    password?:string;
+    date_gmt?: string | null;
+    slug?: string;
+}
+
+export function isWordpressPostDTO (value:any): value is WordpressPostDTO {
+    return (
+        isRegularObject(value)
+        && hasNoOtherKeysInDevelopment(value, [
+            'title',
+            'content',
+            'type',
+            'id',
+            'date',
+            'status',
+            'generated_slug',
+            'permalink_template',
+            'parent',
+            'author',
+            'excerpt',
+            'featured_media',
+            'comment_status',
+            'ping_status',
+            'menu_order',
+            'meta',
+            'template',
+            'password',
+            'date_gmt',
+            'slug'
+        ])
+        && isString(value?.id)
+        && isRegularObject(value?.title)
+        && isRegularObject(value?.content)
+    )
+}

--- a/wordpress/dto/WordpressPostListDTO.ts
+++ b/wordpress/dto/WordpressPostListDTO.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2023. Heusala Group Oy <info@heusalagroup.fi>. All rights reserved.
+
+import { WordpressPostDTO } from "./WordpressPostDTO";
+
+export type WordpressPostListDTO = WordpressPostDTO[];
+
+export function isWordpressPostsDTO (value: any): value is WordpressPostListDTO {
+    return true
+}
+
+export function stringifyWordpressPostDTO (value: WordpressPostListDTO): string {
+    return `WordpressPostDTO(${value})`;
+}
+
+export function parseWordpressPagesDTO (value: any): WordpressPostListDTO | undefined {
+    if ( isWordpressPostsDTO(value)) return value;
+    return undefined;
+}

--- a/wordpress/wordpress-api.ts
+++ b/wordpress/wordpress-api.ts
@@ -2,7 +2,8 @@
 /**
  * `V2 Endpoints /wordpress/v2`
  */
-export const WORD_PRESS_API_V2_PAGES = '/wp-json/wp/v2/pages';
+//TODO The "per_page" is just a TEMPORARY FIX to retrieve more than 10 pages from the CMS.
+export const WORD_PRESS_API_V2_PAGES = '/wp-json/wp/v2/pages?per_page=40';
 
 
 /**

--- a/wordpress/wordpress-api.ts
+++ b/wordpress/wordpress-api.ts
@@ -2,9 +2,9 @@
 /**
  * `V2 Endpoints /wordpress/v2`
  */
-//TODO The "per_page" is just a TEMPORARY FIX to retrieve more than 10 pages from the CMS.
-export const WORD_PRESS_API_V2_PAGES = '/wp-json/wp/v2/pages?per_page=40';
+export const WORD_PRESS_API_V2_PAGES = '/wp-json/wp/v2/pages';
 
+export const WORD_PRESS_API_V2_POSTS = '/wp-json/wp/v2/posts';
 
 /**
  * `V3 Endpoints /wordpress/v3`

--- a/wordpress/wordpress-api.ts
+++ b/wordpress/wordpress-api.ts
@@ -1,10 +1,11 @@
-
 /**
  * `V2 Endpoints /wordpress/v2`
  */
-export const WORD_PRESS_API_V2_PAGES = '/wp-json/wp/v2/pages';
+// export const WORD_PRESS_API_V2_PAGES = '/wp-json/wp/v2/pages';
+export const WORD_PRESS_API_V2_PAGES = '/wp-json/wp/v2/pages?per_page=100';
 
-export const WORD_PRESS_API_V2_POSTS = '/wp-json/wp/v2/posts';
+// export const WORD_PRESS_API_V2_POSTS = '/wp-json/wp/v2/posts';
+export const WORD_PRESS_API_V2_POSTS = '/wp-json/wp/v2/posts?per_page=100';
 
 /**
  * `V3 Endpoints /wordpress/v3`


### PR DESCRIPTION
Contains small a hack to retrieve 100 pages per request instead of 10. There are a non-breaking way to change these functions to accept an optional GET-parameters for WordPress API. Did preminilary tests before, but due to urgent current project not implement these yet.
Also added few DTOs by copying and modifying from original WordpressPageDTO, etc types. Required for the project to work. These can be also write better and some functionality might be combined in the name of DRY.
